### PR TITLE
Include lib/ into the npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "test": "mocha -R spec"
   },
   "files": [
-    "index.js"
+    "index.js",
+    "lib/"
   ],
   "dependencies": {
     "arr-filter": "^1.0.2",


### PR DESCRIPTION
I've just got the `Cannot find module './lib/exp'` error.